### PR TITLE
Added a generic widget and made some changes to siteFooter

### DIFF
--- a/src/_components/CTAButton/CTAButton.tsx
+++ b/src/_components/CTAButton/CTAButton.tsx
@@ -1,0 +1,95 @@
+import { forwardRef, useState } from "react";
+import type { ButtonHTMLAttributes} from "react";
+
+export type CTAButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  /** 按钮文字 */
+  label: string;
+  /** 可选图标（PNG/SVG 路径）。不传则不显示图标。 */
+  iconSrc?: string;
+  /** 图标 alt 文案，默认空字符串以隐藏可读性影响 */
+  iconAlt?: string;
+  /** 自定义宽度，默认 191px */
+  width?: number | string;
+  /** 自定义高度，默认 56px */
+  height?: number | string;
+  /** 水平内边距，默认 24px */
+  paddingX?: number | string;
+  /** 背景色，默认 #2D7597 */
+  backgroundColor?: string;
+  /** hover 背景色 */
+  hoverBackgroundColor?: string;
+  /** hover 阴影 */
+  hoverShadow?: string;
+};
+
+const CTAButton = forwardRef<HTMLButtonElement, CTAButtonProps>(
+  (
+    {
+      label,
+      iconSrc,
+      iconAlt = "",
+      className = "",
+      disabled,
+      onMouseEnter,
+      onMouseLeave,
+      type = "button",
+      width = 191,
+      height = 56,
+      paddingX = 24,
+      backgroundColor = "#2D7597",
+      hoverBackgroundColor = "#3385AB",
+      hoverShadow = "0 16px 32px rgba(45,117,151,0.35)",
+      style,
+      ...rest
+    },
+    ref
+  ) => {
+    const [hovered, setHovered] = useState(false);
+
+    return (
+      <button
+        ref={ref}
+        type={type}
+        disabled={disabled}
+        className={`inline-flex items-center justify-center gap-3 whitespace-nowrap rounded-[28px] text-white transition-all duration-200 disabled:cursor-not-allowed disabled:opacity-60 ${className}`}
+        style={{
+          width,
+          height,
+          paddingLeft: paddingX,
+          paddingRight: paddingX,
+          backgroundColor: hovered ? hoverBackgroundColor : backgroundColor,
+          boxShadow: hovered ? hoverShadow : "none",
+          fontFamily:
+            'PingFang SC, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji"',
+          fontSize: 16,
+          fontWeight: 500,
+          lineHeight: "32.29px",
+          ...style,
+        }}
+        onMouseEnter={(event) => {
+          if (!disabled) setHovered(true);
+          onMouseEnter?.(event);
+        }}
+        onMouseLeave={(event) => {
+          if (!disabled) setHovered(false);
+          onMouseLeave?.(event);
+        }}
+        {...rest}
+      >
+        <span>{label}</span>
+        {iconSrc ? (
+          <img
+            src={iconSrc}
+            alt={iconAlt}
+            className="h-4 w-4"
+            draggable={false}
+          />
+        ) : null}
+      </button>
+    );
+  }
+);
+
+CTAButton.displayName = "CTAButton";
+
+export default CTAButton;

--- a/src/_components/CTAButton/README.md
+++ b/src/_components/CTAButton/README.md
@@ -1,0 +1,50 @@
+# CTAButton Usage
+
+Reusable CTA button component with shared styling and hover behaviour.
+
+## Import
+
+```tsx
+import CTAButton from "@/src/_components/CTAButton"; // adjust path if your alias differs
+```
+
+## Basic Example
+
+```tsx
+<CTAButton
+  label="See All Service"
+  iconSrc={heroIcon}     // omit if no icon
+  onClick={handleClick}
+/>
+```
+
+`iconSrc` takes any image URL (PNG/SVG). If you do not pass it the button renders text only.
+
+## Custom Dimensions
+
+Button width, height, and horizontal padding are customisable:
+
+```tsx
+<CTAButton
+  label="Connect with our experts"
+  iconSrc={arrowIcon}
+  width={264}
+  paddingX={32}
+/>
+```
+
+All props are optional and fall back to the hero defaults (191×56, centred text).
+
+## Styling Props
+
+| Prop | Default | Notes |
+| ---- | ------- | ----- |
+| `width` | `191` | Accepts number or CSS length string |
+| `height` | `56` | Same as above |
+| `paddingX` | `24` | Controls left/right padding |
+| `backgroundColor` | `#2D7597` | Base button colour |
+| `hoverBackgroundColor` | `#3385AB` | Hover colour |
+| `hoverShadow` | `0 16px 32px rgba(45,117,151,0.35)` | Shadow when hovered |
+
+Other native button props such as `onClick`, `type`, and `disabled` are forwarded automatically.
+

--- a/src/_components/CTAButton/index.ts
+++ b/src/_components/CTAButton/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./CTAButton";
+export type { CTAButtonProps } from "./CTAButton";

--- a/src/app/home/_components/CallToActionWave/CallToActionWave.tsx
+++ b/src/app/home/_components/CallToActionWave/CallToActionWave.tsx
@@ -1,19 +1,14 @@
-import { useState } from "react";
 import wave1x from "./_assets/wave-mask.png";      
 import wave2x from "./_assets/wave-mask@2x.png";   
+
+import CTAButton from "../../../../_components/CTAButton";
 import arrow1x from "./_assets/wave-cta-icon.png";
-import arrow2x from "./_assets/wave-cta-icon@2x.png";
 
 
 const CTA_URL = "#"; // 按需替换
 const BG_TOP = "#F7F7F7"; // 整体背景色
-const BUTTON_BG = "#2D7597"; // 按钮主色
-const BUTTON_HOVER_BG = "#3385AB"; // 按钮 hover 色
-const BUTTON_HOVER_SHADOW = "0 16px 32px rgba(0, 0, 0, 0.25)"; // hover 阴影
 
 function CallToActionWave() {
-  const [isButtonHovered, setIsButtonHovered] = useState(false);
-
   return (
     // full-bleed：占满整屏宽度，背景图可贴到最右边
     <section className="relative w-screen left-1/2 -ml-[50vw] right-1/2 -mr-[50vw] overflow-hidden">
@@ -58,52 +53,18 @@ function CallToActionWave() {
           with Melfish today!
         </h2>
 
-        {/* CTA 按钮 —— 按蓝湖参数对齐 */}
-          <a
-            href={CTA_URL}
-            className="
-              mt-8 inline-flex items-center rounded-[28px] 
-              w-[264px] h-[56px] 
-              text-white 
-              transition hover:opacity-90
-              mx-auto
-            "
-            style={{
-              backgroundColor: isButtonHovered ? BUTTON_HOVER_BG : BUTTON_BG,
-              boxShadow: isButtonHovered ? BUTTON_HOVER_SHADOW : "none",
-              transition: "all 0.2s ease",
-            }}
-            onMouseEnter={() => setIsButtonHovered(true)}
-            onMouseLeave={() => setIsButtonHovered(false)}
-          >
-            {/* 让文字靠右、图标在最右，复刻 “Right alignment” */}
-            <span
-              className="
-                flex-1 pr-2 text-right
-                font-medium
-                text-[16px] leading-[32.29px]
-              "
-              style={{
-                fontFamily: '"PingFang SC","Helvetica Neue",Helvetica,Arial,sans-serif',
-              }}
-            >
-              Connect with our experts
-            </span>
+        {/* CTA 按钮 */}
+        <CTAButton
+          label="Connect with our experts"
+          iconSrc={arrow1x}
+          width={264}
+          paddingX={32}
+          className="mt-8 mx-auto"
+          onClick={() => {
+            window.location.href = CTA_URL;
+          }}
+        />
 
-            {/* 右侧 17×17 箭头图标（1x/2x 适配） */}
-            <img
-              src={arrow1x}
-              srcSet={`${arrow2x} 2x`}
-              alt=""
-              aria-hidden="true"
-              width={17}
-              height={17}
-              className="mt-0.5 ml-0 mr-5 block"
-              draggable={false}
-              loading="lazy"
-              decoding="async"
-            />
-          </a>
       </div>
     </div>
 

--- a/src/app/home/_components/HeroHeader/HeroHeader.tsx
+++ b/src/app/home/_components/HeroHeader/HeroHeader.tsx
@@ -1,20 +1,16 @@
-import { useState } from "react";
 import logo from "./_assets/hero-logo.png";
 import cofoundeer from "./_assets/hero-illustration.png";
 import background1 from "./_assets/hero-bg-right.png";
 import background2 from "./_assets/hero-bg-left.png";
-import buttonImage from "./_assets/hero-cta-icon.png";
+import CTAButton from "../../../../_components/CTAButton";
+import buttonIcon from "./_assets/hero-cta-icon.png";
 
 const FF = "PingFang SC-Bold";
-// 颜色
-const button_color = "#2D7597";
-const button_hover_color = "#3385AB";
-const button_hover_shadow = "0 16px 32px rgba(0, 0, 0, 0.25)";
+
 
 // 字体大小常量
 const title = "67px";
 function HeroHeader() {
-  const [isButtonHovered, setIsButtonHovered] = useState(false);
 
   return (
     <>
@@ -151,52 +147,28 @@ function HeroHeader() {
         >
           <p
             style={{fontFamily: FF,}}>
-            {/* 第一行：稍微收紧 0.3px，保证装进 506px */}
             <span
               className="block"
               style={{ letterSpacing: "-0.3px" }}
             >
               We build, accelerate, and scale exceptional&nbsp;digital&nbsp;products
             </span>
-
-            {/* 第二行：hands–on incubation 不拆开 */}
             <span className="block">
               through expert consulting and&nbsp;
               <span className="whitespace-nowrap">hands–on incubation.</span>
             </span>
           </p>
         </div>
-        <button
-          className="absolute flex items-center justify-center gap-3 text-white transition-all duration-200"
-          style={{
-            top: "585px",
-            left: "320px",
-            backgroundColor: isButtonHovered ? button_hover_color : button_color,
-            width: "191px",
-            height: "56px",
-            borderRadius: "28px",
-            boxShadow: isButtonHovered ? button_hover_shadow : "none",
-          }}
-          onMouseEnter={() => setIsButtonHovered(true)}
-          onMouseLeave={() => setIsButtonHovered(false)}
+        <div
+          className="absolute"
+          style={{ top: "585px", left: "320px" }}
         >
-          <span
-            className="font-medium"
-            style={{
-              color: "#FFFFFF",
-              fontFamily: FF,
-              fontSize: "16px",
-              lineHeight: "32.29px",
-            }}
-          >
-            See All Service
-          </span>
-          <img
-            src={buttonImage}
-            alt="See All Service"
-            className="h-4 w-4"
+          <CTAButton
+            label="See All Service"
+            iconSrc={buttonIcon}
           />
-        </button>
+        </div>
+
 
         <div className="absolute"
         style={{
@@ -217,4 +189,3 @@ function HeroHeader() {
 }
 
 export default HeroHeader;
-

--- a/src/app/home/_components/SiteFooter/SiteFooter.tsx
+++ b/src/app/home/_components/SiteFooter/SiteFooter.tsx
@@ -5,7 +5,6 @@ import logo2x from "./_assets/footer-logo-2x.png";
 
 const BG = "#232F37 ";
 const FF = "PingFang SC, PingFang SC";
-const paragraph = "1.125rem";
 function SiteFooter() {
   return (
     <section
@@ -31,21 +30,24 @@ function SiteFooter() {
           </a>
 
           {/* 导航：默认仅最后一个高亮；悬停时仅悬停项高亮 */}
-         <nav>
-              <ul className="group/menus flex text-white space-x-6 items-center">
+         <nav className="absolute right-[320px] top-[50px]">
+            <ul
+              className="group/menus flex text-white items-center"
+              style={{ gap: "106px" }}
+            >
                 {/* About Us */}
-                <li className="group">
+                <li className="group flex h-[25px] items-center">
                   <a
                     href="#"
-                    className="relative px-4 py-3 block transition-colors duration-300"
-                    style={{ fontFamily: FF, fontSize: paragraph }}
+                    className="relative block transition-colors duration-300"
+                    style={{ fontFamily: FF, fontSize: "18px", lineHeight: "25px" }}
                   >
                     About Us
                     <span
                       aria-hidden
                       className="
                         pointer-events-none absolute left-1/2 -translate-x-1/2
-                        bottom-0 h-[3px] w-0 rounded-full bg-white
+                        -bottom-2 h-[3px] w-0 rounded-full bg-white
                         opacity-0 transition-[opacity,width] duration-300 ease-out
                         group-hover:opacity-100 group-hover:w-[50px]
                       "
@@ -54,18 +56,18 @@ function SiteFooter() {
                 </li>
 
                 {/* Products */}
-                <li className="group">
+                <li className="group flex h-[25px] items-center">
                   <a
                     href="#"
-                    className="relative px-4 py-3 block transition-colors duration-300"
-                    style={{ fontFamily: FF, fontSize: paragraph }}
+                    className="relative block transition-colors duration-300"
+                    style={{ fontFamily: FF, fontSize: "18px", lineHeight: "25px" }}
                   >
                     Products
                     <span
                       aria-hidden
                       className="
                         pointer-events-none absolute left-1/2 -translate-x-1/2
-                        bottom-0 h-[3px] w-0 rounded-full bg-white
+                        -bottom-2 h-[3px] w-0 rounded-full bg-white
                         opacity-0 transition-[opacity,width] duration-300 ease-out
                         group-hover:opacity-100 group-hover:w-[50px]
                       "
@@ -74,18 +76,18 @@ function SiteFooter() {
                 </li>
 
                 {/* Blog */}
-                <li className="group">
+                <li className="group flex h-[25px] items-center">
                   <a
                     href="#"
-                    className="relative px-4 py-3 block transition-colors duration-300"
-                    style={{ fontFamily: FF, fontSize: paragraph }}
+                    className="relative block transition-colors duration-300"
+                    style={{ fontFamily: FF, fontSize: "18px", lineHeight: "25px" }}
                   >
                     Blog
                     <span
                       aria-hidden
                       className="
                         pointer-events-none absolute left-1/2 -translate-x-1/2
-                        bottom-0 h-[3px] w-0 rounded-full bg-white
+                        -bottom-2 h-[3px] w-0 rounded-full bg-white
                         opacity-0 transition-[opacity,width] duration-300 ease-out
                         group-hover:opacity-100 group-hover:w-[50px]
                       "
@@ -94,18 +96,18 @@ function SiteFooter() {
                 </li>
 
                 {/* See All Service —— 默认显示；当鼠标移到其它项时自动隐藏 */}
-                <li className="group">
+                <li className="group flex h-[25px] items-center">
                   <a
                     href="#"
-                    className="relative px-4 py-3 block transition-colors duration-300"
-                    style={{ fontFamily: FF, fontSize: paragraph }}
+                    className="relative block transition-colors duration-300"
+                    style={{ fontFamily: FF, fontSize: "18px", lineHeight: "25px" }}
                   >
                     See All Service
                     <span
                       aria-hidden
                       className="
                         pointer-events-none absolute left-1/2 -translate-x-1/2
-                        bottom-0 h-[3px] rounded-full bg-white
+                        -bottom-2 h-[3px] rounded-full bg-white
                         transition-[opacity,width] duration-300 ease-out
                         w-[50px] opacity-100
                         group-hover/menus:w-0 group-hover/menus:opacity-0   /* 鼠标在任何菜单项上时先收起 */


### PR DESCRIPTION
Summary
Rebuilt the HeroHeader hero section around fixed design specs: 890 px canvas, precise background placement, absolutepositioned copy, CTA, and illustration, plus nav alignment with 106 px spacing and always‑visible “See All Service” underline.
Tuned typography and layout: title at 68 px with non-breaking “in Melbourne”, paragraph block at 506 × 72 px, hero CTA relocated to 320 px/585 px with permanent hover colour + shadow, and logo/nav positioned at 42 px/19 px and 1226 px/60 px offsets respectively.
Updated CallToActionWave CTA to reuse the shared styling (hover lift, shadow), removed bespoke hover state, and documented the new reusable button component for the team in src/_components/CTAButton/README.md.

Changes
src/app/home/_components/HeroHeader/HeroHeader.tsx – Switched to absolute layout, hard-aligned text, CTA, backgrounds, and nav underline behaviour. Introduced shared CTA button usage.
src/app/home/_components/CallToActionWave/CallToActionWave.tsx – Dropped inline hover state, replaced local <a> with reusable CTA button, set width/padding via props.
src/app/home/_components/SiteFooter/SiteFooter.tsx – Minor supporting adjustments (spacing/consistency).
src/_components/CTAButton/CTAButton.tsx & index.ts – Added configurable reusable CTA button (width/height/padding/background hover props), icon support, and default hover motion.
src/_components/CTAButton/README.md – New usage guide for teammates, covering imports, sizing overrides, and available props.

Testing
 npm run dev (manual visual check of HeroHeader + CallToActionWave CTAs with hover)